### PR TITLE
Support methods without arglists

### DIFF
--- a/lib/Guacamole.pm
+++ b/lib/Guacamole.pm
@@ -542,6 +542,7 @@ ArrowDerefCall     ::= CallArgs
 ArrowDerefVariable ::= DerefVariableArgsAll
                      | DerefVariableSlice
 ArrowMethodCall    ::= SubNameExpr CallArgs
+                     | SubNameExpr
 ArrowIndirectCall  ::= SigilScalar VarIdentExpr CallArgs
 
 DerefVariableArgsAll ::= '$*' | '@*' | '%*' | '&*' | '**' | '$#*'

--- a/t/Statements/Expressions/arrow.t
+++ b/t/Statements/Expressions/arrow.t
@@ -14,6 +14,6 @@ parses('$foo->thing()');
 parses('"Foo"->thing()');
 parses('Foo->thing()');
 
-parsent('Foo->thing;');
+parses('Foo->thing;');
 
 done_testing;

--- a/t/Statements/SubStatement.t
+++ b/t/Statements/SubStatement.t
@@ -19,7 +19,9 @@ parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
 
 parses('Foo->method();');
 parsent('Foo::->method();');
-parsent('Foo->method;');
+parses('Foo->method;');
+parses('Foo->method->chain;');
+parses('$object->method->chain->two;');
 
 # make sure we didn't screw up non q-like subroutines
 


### PR DESCRIPTION
While this supports the syntaxes:

 $object->method
 Package->method

... it also supports chaining method calls:

 $object->method_one->method_two->method_foo
 Package->new->some->methods