### PR TITLE
Add documentation to two main modules

### DIFF
--- a/lib/Guacamole.pm
+++ b/lib/Guacamole.pm
@@ -2081,15 +2081,131 @@ __END__
     use Guacamole;
     my ($ast) = Guacamole->parse($string);
 
-=head1 WHERE'S THE REST
+=head1 DESCRIPITON
 
-Gotta write it... Give us time!
+B<Guacamole> is a Perl parser toolkit.
 
-"Standard Perl" aims to use only the syntax that makes Perl easy to
-parse. A Perl static parser such as Guacamole isn't that hard if we
-avoid a small set of constructs that cause parser ambiguities. These
-cases are listed in the L<Guacamole wiki|https://github.com/xsawyerx/guacamole/wiki>.
+It can:
+
+=over 4
+
+=item * Parse Standard Perl
+
+This is explained in this document.
+
+For B<Standard Perl>, see the next clause.
+
+=item * Check a file is written in Standard Perl
+
+This is done by L<standard>, which is where Standard Perl is described.
+
+=item * Lint your code
+
+See L<Guacamole::Linter>.
+
+=item * Deparse your code
+
+See L<Guacamole::Deparse>.
+
+=item * Rewrite your code
+
+There is a proof-of-concept for this and we hope to provide this as a framework.
+
+=back
+
+=head1 Standard Perl
+
+Guacamole only works on Standard Perl. You can read about it here: L<standard>.
+
+=head1 Parser
+
+    my ($ast) = Guacamole->parse($string);
+
+To parse a string, call L<Gaucamole>'s C<parse> method. (This might turn to an
+object-oriented interface in the future.)
+
+It returns a list of results. If it ever returns more than one, this is a bug that
+means it couldn't ambiguously parse something. This will later be enforced in the
+interface. The current interface is not official.
+
+=head2 AST Nodes
+
+Guacamole returns an AST with two types of nodes.
+
+    my ($ast) = Guacamole->parse('$foo = 1');
+
+The above will generate a larger AST than you imagine (which might be pruned
+in the future). We'll focus on two types of nodes that will appear above.
+
+=head3 Rules
+
+Rules are the top level expressions. They include the definitions for rules.
+They include information on location in the file, length, line, and column.
+
+    $rule = {
+        'children'  => [...],
+        'column'    => 2,
+        'length'    => 3,
+        'line'      => 1,
+        'name'      => 'VarIdentExpr',
+        'start_pos' => 1,
+        'type'      => 'rule',
+    },
+
+This rule is a C<VarIdentExpr> which is an expression for a variable identity.
+
+In the code above, it refers to the C<foo> in C<$foo> - which is the identity
+itself.
+
+It has one child, described below under C<Lexemes>.
+
+=head3 Lexemes
+
+The child for the C<VarIdentExpr> rule should be the value of the identity.
+
+    $lexeme = {
+        'name'  => '',
+        'type'  => 'lexeme',
+        'value' => 'foo',
+    };
+
+The C<name> attribute for all lexemes is empty. This is to make it easy to
+write code that checks for the value of a rule without having to check whether
+it's a rule first.
+
+=head1 THANKS
+
+=over 4
+
+=item * Damian Conway
+
+For helping understand what is feasible, what isn't, and why, and for having
+infinite patience in explaining these.
+
+=item * Jeffrey Kegler
+
+For L<Marpa> and helping understand how to use Marpa better.
+
+=item * Gonzalo Diethelm
+
+For continuous feedback and support.
+
+=item * H. Merijn Brand (@Tux)
+
+For providing the initial production-level test of Guacamole to
+help shake many of the bugs in the BNF.
+
+=back
 
 =head1 SEE ALSO
 
-L<standard>
+=over 4
+
+=item * L<standard>
+
+=item * L<Gaucamole::Linter>
+
+=item * L<Guacamole::Deparse>
+
+=back
+

--- a/lib/standard.pm
+++ b/lib/standard.pm
@@ -66,9 +66,240 @@ __END__
     use standard;
     # Now you will get a warning if you don't conform to Standard Perl
 
-=head1 WHERE'S THE REST
+=head1 DESCRIPTION
 
-Soon...
+B<Standard Perl> aims to use only the syntax that makes Perl easy to parse.
+A Perl static parser such as Guacamole isn't that hard if we avoid a small
+set of constructs that cause parser ambiguities.
+
+These changes are described below. Over time, this documentation will explain
+the standard itself versus the differences between this subset and what the
+perl interpreter supports.
+
+=head1 DIFFERENCES
+
+=head2 Things not supported
+
+This list covers constructs that the perl interpreter understands (for whatever
+value of "understand" is) but that that Standard Perl does not support.
+
+=over 4
+
+=item * Auto-quoting
+
+Perl's auto-quoting rules are... rather elaborate and awkward. Much of it is
+unknown and can even depend on lowercase vs. uppercase and specific letters with
+special meaning to the interpreter and not the user.
+
+Thus, a string in Standard Perl is always quoted.
+
+    $foo{key}   # not ok
+    $foo{'key'} # ok
+
+    %hash = ( foo   => 'bar' ); # not ok
+    %hash = ( 'foo' => 'bar' ); # ok
+
+=item * HEREDOCs
+
+HEREDOCs are a monstrosity for parsers and cannot be expressed with a BNF. It is
+thus not supported.
+
+    # This will fail
+    my $value = << '_END_OF_VALUE';
+    ...
+    _END_OF_VALUE
+
+    # This is an alternative
+    my $value =
+    q{...
+    };
+
+    # This is another alternative:
+    my $value = q{
+    ...
+    } =~ s/^\n//r;
+
+=item * Indirect object notation
+
+    my $instance = new Class;    # not ok
+    my $instance = Class->new(); # ok 
+
+=item * Bareword filehandles
+
+    open FOO, ...    # not ok
+    open my $fh, ... # ok
+    open $fh, ...    # also ok
+
+    print STDOUT $foo; # also ok
+    print STDERR $foo; # also ok
+
+    while ( <FOO>   ) {...} # not ok
+    while ( <$foo>  ) {...} # ok
+    while ( <STDIN> ) {...} # also ok
+
+The following bareword filehandles are supported:
+
+=over 4
+
+=item * C<STDIN>
+
+=item * C<STDOUT>
+
+=item * C<STDERR>
+
+=item * C<ARGV>
+
+=item * C<ARGVOUT>
+
+=item * C<DATA>
+
+=back
+
+=item * Printing to filehandles with no brace
+
+    print $fh $foo;   # not ok
+    print {$fh} $foo; # ok
+
+
+=item * C<_> in file operations
+
+    if ( -f $foo && -r _ )    {...} # not ok
+    if ( -f $foo && -r $foo ) {...} $ ok
+
+=item * C<given> / C<when> / C<default>
+
+Not supported.
+
+=back
+
+=head2 Things we changed
+
+The following are limitations that Standard Perl has which the perl
+interepreter doesn't.
+
+=head3 Q-Like values delimiters
+
+Q-Like values are one of the following: C<q>, C<qq>, C<qw>, C<qx>, C<qr>
+
+However, the following limitations also apply to: C<m//>, C<s///> C<tr///>,
+and C<y///>.
+
+=over 4
+
+=item * No nested delimiters
+
+    $val = q< <> >;    # not ok
+    $val = q< \<\> >;  # ok
+
+If you want to use the delimiter within delimited space, escape it.
+
+=item * Limited delimiters
+
+Only the following delimiters are supported:
+
+C<()>, C<[]>, C<{}>, C<< E<lt> E<gt> >>, C<//>, C<!!>, and C<||>.
+
+    $val = q(...) # ok
+    $val = q[...] # ok
+    $val = q{...} # ok
+    $val = q<...> # ok
+    $val = q/.../ # ok
+    $val = q!...! # ok
+    $val = q|...| # ok
+
+    $val = q@...@    # not ok
+    $val = q#...#    # not ok
+    $val = q Z ... Z # not ok
+
+=item * No spaces between before delimiters:
+
+    q <foo> # not ok
+    q<foo>  # ok
+    q ()    # not ok
+    q()     # ok
+
+=back
+
+=head3 Subroutines
+
+=over 4
+
+=item * B<All> subroutines must use parentheses
+
+    foo $bar   # not ok
+    foo($bar)  # ok
+
+=item * Subroutines can have attributes and signatures
+
+Standard Perl accepts both attributes and signatures.
+
+=item * All subroutine prototypes must be declared using an attribute
+
+    sub foo ($)           {...} # signature, not prototype
+    sub foo :prototype($) {...} # prototype, not signature
+
+=item * Prototypes do not change the parsing rules
+
+    first {...} @foo         # not ok
+    first( sub {...}, @foo ) # ok
+
+We are looking into allowing developers to have their grammars hooking
+up to the L<Guacamole> parser so it could allow to extend Standard Perl.
+This will be useful for stuff like L<List::Util>, L<Dancer2>,
+L<Mojolicious::Lite>, L<Moose>, etc.
+
+Having said that, Standard Perl doesn't accept this.
+
+=back
+
+=head3 Class names
+
+=over 4
+
+=item * Left of arrow is always an invocant, never a function
+
+    Foo->new(); # always a class, never a function "Foo"
+
+This is tricky because the perl interpreter might see a function called
+C<foo> in the same scope and call that instead. This would mean that
+Standard Perl and the perl interpreter would report different results.
+
+We have a shim layer in L<standard> that checks for this and alerts if
+this will happen, so you never hit this issue when using C<standard>.
+
+We advise other parsers who use Standard Perl BNF to include this part.
+
+=item * Namespaces cannot end with a double colon
+
+    Foo->bar();   # ok
+    Foo::->bar(); # not ok
+
+This might be changed.
+
+=back
+
+=head3 Dereferencing
+
+=over 4
+
+=item * Prefixed dereferencing is only supported with braces
+
+    @$foo    # not ok
+    @{$foo}  # ok
+    $foo->@* # ok
+
+=back
+
+=head3 Expressions
+
+=over 4
+
+=item * map that attempts to return a pair must use parenthesis
+
+    map {   $_ => 1   }, @foo  # not ok
+    map { ( $_ => 1 ) }, @foo  # ok
+
+=back
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This documents both `Guacamole.pm`, as well as `standard.pm`.

It's mostly the content from the presentation on Guacamole.